### PR TITLE
ci: remove auto committing of generated files

### DIFF
--- a/.github/workflows/generate_go.yaml
+++ b/.github/workflows/generate_go.yaml
@@ -1,4 +1,4 @@
-name: generate-go-source
+name: Test generating sources
 
 on: [push]
 
@@ -14,11 +14,8 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
 
-      - name: Generate sources
+      - name: Test generate sources
         run: |
           PATH=/home/runner/go/bin:${PATH}
           make clean all
 
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Generate Golang source


### PR DESCRIPTION
The current system of automatically generating and pushing commits to feature branches is likely not working as intended. The current system seems to do a lot of unintended changes when trivial changes to the source code are applied.

This ensures that no one can merge anything into the default branch without having to understand all the generated code changes.

In addition, feature branches should be complete when pushed by a developer, and should not receive additional commits upon being pushed, as this would be surprising to many developers.

Also renamed the relevant names in the workflow file.