### PR TITLE
Update proto compiler tooling

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
-PROTOC_VERSION=3.19.2
+PROTOC_VERSION=23.3
 DIRS=commons config contentwriter dnsresolver frontier robotsevaluator browsercontroller eventhandler ooshandler controller report scopechecker uricanonicalizer log
 
 .PHONY: all
@@ -20,8 +20,8 @@ tools:
 	&& wget -q https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip \
 	&& unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip \
 	&& rm protoc-${PROTOC_VERSION}-linux-x86_64.zip \
-	&& go get google.golang.org/protobuf/cmd/protoc-gen-go \
-	google.golang.org/grpc/cmd/protoc-gen-go-grpc
+	&& go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31 \
+	&& go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
 
 $(DIRS): tools
 	find ../protobuf -name *.proto -exec 'tools/bin/protoc' '-I../protobuf' '-Itools/include' '--go_out=.' '--go_opt=paths=source_relative' '--go-grpc_out=.' '--go-grpc_opt=paths=source_relative' '{}' ';'


### PR DESCRIPTION
This PR updates protoc to latest version and go plugins to a known version.

Fixes generation of code by installing plugins
instead of just getting the source.